### PR TITLE
Only apply colors when output is a terminal

### DIFF
--- a/pjson
+++ b/pjson
@@ -46,5 +46,8 @@ def color_yo_shit(code):
 if __name__ == '__main__':
     for line in sys.stdin:
         code = format_json_code(line)
-        print color_yo_shit(code)
+        if sys.stdout.isatty():
+            print color_yo_shit(code)
+        else:
+            print code
 


### PR DESCRIPTION
This allows you to pipe to tools like "less" without adding the colors so it will display correctly.

It still colors when dumping to a terminal directly.
