### PR TITLE
Handled exception when json not provided

### DIFF
--- a/pjson/__init__.py
+++ b/pjson/__init__.py
@@ -69,7 +69,10 @@ def main():
     else:
         data = sys.stdin.read()
         if sys.stdout.isatty():
-            data = color_yo_shit(format_code(data, args.x), XmlLexer() if args.x else JSONLexer())
+            try:
+                data = color_yo_shit(format_code(data, args.x), XmlLexer() if args.x else JSONLexer())
+            except ValueError as e:
+                print e
         print(data)
 
 if __name__ == '__main__':


### PR DESCRIPTION
Spewing a traceback when there's no input is lame. Now it just prints an error message!
