### PR TITLE
Pygments 1.6 and python 3 fixes

### DIFF
--- a/pjson/__init__.py
+++ b/pjson/__init__.py
@@ -28,7 +28,7 @@ else:
     from io import StringIO
 from pygments import highlight
 from pygments.formatters import TerminalFormatter
-from pygments.lexers import JSONLexer, XmlLexer
+from pygments.lexers import JsonLexer, XmlLexer
 import xml.dom.minidom
 import argparse
 
@@ -65,12 +65,12 @@ def main():
         exit(1)
     elif args.b:
         for line in sys.stdin:
-            print(color_yo_shit(format_code(line), JSONLexer()))
+            print(color_yo_shit(format_code(line), JsonLexer()))
     else:
         data = sys.stdin.read()
         if sys.stdout.isatty():
             try:
-                data = color_yo_shit(format_code(data, args.x), XmlLexer() if args.x else JSONLexer())
+                data = color_yo_shit(format_code(data, args.x), XmlLexer() if args.x else JsonLexer())
             except ValueError as e:
                 print (e)
         print(data)

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,6 @@ setup(
         'console_scripts': ['pjson = pjson:main']
     },
     install_requires=[
-        'Pygments==1.5'
+        'Pygments==1.6'
     ]
 )


### PR DESCRIPTION
While [packaging](https://aur.archlinux.org/packages/pjson-git/) your nifty tool for Arch Linux, I encountered 2 problems.
Arch ships Pygments 1.6 currently and the standard python interpreter is 3.x.
With my changes it works as expected.
