### PR TITLE
Allow color when piping (flag -t), don't always colorize when using -b, other fixes

### DIFF
--- a/pjson/__init__.py
+++ b/pjson/__init__.py
@@ -91,4 +91,7 @@ def main():
             exit(1)
 
 if __name__ == '__main__':
-    main()
+    try:
+        main()
+    except KeyboardInterrupt:
+        exit(1)


### PR DESCRIPTION
The -t flag is great.

I can just do: `alias pjson='pjson -t'` and this solves #9.

Lexing errors are now optionally colorized.

^C should not result in a zero exit code, nor should bad input.
